### PR TITLE
Rename som functions to clarify issuance limit vs max supply

### DIFF
--- a/contracts/interfaces/ISWSupplyManager.sol
+++ b/contracts/interfaces/ISWSupplyManager.sol
@@ -28,12 +28,12 @@ interface ISWSupplyManager {
   |__________________________________*/
 
   /**
-   * @notice Set max supply for some token IDs that can't ever be increased
-   * @dev Can only decrease the max supply if already set, but can't set it *back* to 0.
-   * @param _ids Array of token IDs to set the max supply
-   * @param _supplies Array of max supplies for each corresponding ID
+   * @notice Set max issuance for some token IDs that can't ever be increased
+   * @dev Can only decrease the max issuance if already set, but can't set it *back* to 0.
+   * @param _ids Array of token IDs to set the max issuance
+   * @param _newMaxIssuances Array of max issuances for each corresponding ID
    */
-  function setMaxSupplies(uint256[] calldata _ids, uint256[] calldata _supplies) external;
+  function setMaxIssuances(uint256[] calldata _ids, uint256[] calldata _newMaxIssuances) external;
 
   /***********************************|
   |     Factory Management Methods    |
@@ -113,16 +113,20 @@ interface ISWSupplyManager {
   function getFactoryAccessRanges(address _factory) external view returns ( AssetRange[] memory);
 
   /**
-   * @notice Get the max supply of multiple asset ID
+   * @notice Get the max issuance of multiple asset IDs
+   * @dev The max issuance of a token does not reflect the maximum supply, only
+   *      how many tokens can be minted once the maxIssuance for a token is set.
    * @param _ids Array containing the assets IDs
-   * @return The current max supply of each asset ID in _ids
+   * @return The current max issuance of each asset ID in _ids
    */
-  function getMaxSupplies(uint256[] calldata _ids) external view returns (uint256[] memory);
+  function getMaxIssuances(uint256[] calldata _ids) external view returns (uint256[] memory);
 
   /**
-   * @notice Get the current supply of multiple asset ID
+   * @notice Get the current issuanc of multiple asset ID
+   * @dev The current issuance of a token does not reflect the current supply, only
+   *      how many tokens since a max issuance was set for a given token id.
    * @param _ids Array containing the assets IDs
-   * @return The current supply of each asset ID in _ids
+   * @return The current issuance of each asset ID in _ids
    */
-  function getCurrentSupplies(uint256[] calldata _ids) external view returns (uint256[] memory);
+  function getCurrentIssuances(uint256[] calldata _ids)external view returns (uint256[] memory);
 }

--- a/src/tests/EternalHeroesFactory.spec.ts
+++ b/src/tests/EternalHeroesFactory.spec.ts
@@ -134,7 +134,7 @@ contract('EternalHeroesFactory', (accounts: string[]) => {
 
     // Set max supplies
     let max_supplies = new Array(nTokenTypes).fill('').map((i) => maxSupply)
-    await skyweaverAssetsContract.functions.setMaxSupplies(ids, max_supplies)
+    await skyweaverAssetsContract.functions.setMaxIssuances(ids, max_supplies)
   })
 
   describe('Getter functions', () => {
@@ -467,7 +467,7 @@ contract('EternalHeroesFactory', (accounts: string[]) => {
       }
 
       // Double check all assets were purchased up to max supply
-      let supplies = await skyweaverAssetsContract.functions.getCurrentSupplies(ids)
+      let supplies = await skyweaverAssetsContract.functions.getCurrentIssuances(ids)
       for (let i = 0; i < ids.length; i++){
         expect(supplies[i]).to.be.eql(maxSupply)
       }
@@ -487,14 +487,14 @@ contract('EternalHeroesFactory', (accounts: string[]) => {
         await userArcadeumCoinContract.functions.safeTransferFrom(userAddress, factory, arcID, cost, full_data, TX_PARAM)
       }
 
-      let supplies = await skyweaverAssetsContract.functions.getCurrentSupplies(ids)
+      let supplies = await skyweaverAssetsContract.functions.getCurrentIssuances(ids)
       // Check if indeed max supply is reached
       for (let i =0; i < nTokenTypes; i++){
         expect(supplies[i]).to.be.eql(maxSupply)
       }
       let data = getBuyHeroesData(userAddress, [ids[0]], [new BigNumber(1)], [n_tiers.add(1)])
       let tx = userArcadeumCoinContract.functions.safeTransferFrom(userAddress, factory, arcID, cost, data, TX_PARAM)
-      await expect(tx).to.be.rejectedWith(RevertError("SWSupplyManager#_validateMints: MAX_SUPPLY_EXCEEDED"))
+      await expect(tx).to.be.rejectedWith(RevertError("SWSupplyManager#_validateMints: MAX_ISSUANCE_EXCEEDED"))
     })
   
     context('Using safeBatchTransferFrom', () => {
@@ -536,7 +536,7 @@ contract('EternalHeroesFactory', (accounts: string[]) => {
       })
 
       it('should update heroes supplies', async () => {
-        let supplies = await skyweaverAssetsContract.functions.getCurrentSupplies(ids)
+        let supplies = await skyweaverAssetsContract.functions.getCurrentIssuances(ids)
         for (let i = 0; i < supplies.length; i++) {
           expect(supplies[i]).to.be.eql(purchaseAmount)
         }

--- a/src/tests/SWSupplyManager.spec.ts
+++ b/src/tests/SWSupplyManager.spec.ts
@@ -119,27 +119,27 @@ contract('SWSupplyManager', (accounts: string[]) => {
 
   describe('Getter functions', () => {
 
-    describe('getMaxSupplies() function', () => {
+    describe('getMaxIssuances() function', () => {
       it('should return correct value', async () => {
         const id = new BigNumber(981273918273)
-        const maxSupply = new BigNumber(100)
-        await SWSupplyManagerContract.functions.setMaxSupplies([id], [maxSupply])
-        const value = await SWSupplyManagerContract.functions.getMaxSupplies([id])
-        expect(value[0]).to.be.eql(maxSupply)
+        const maxIssuance = new BigNumber(100)
+        await SWSupplyManagerContract.functions.setMaxIssuances([id], [maxIssuance])
+        const value = await SWSupplyManagerContract.functions.getMaxIssuances([id])
+        expect(value[0]).to.be.eql(maxIssuance)
       })
     })
 
-    describe('getCurrentSupplies() function', () => {
+    describe('getCurrentIssuances() function', () => {
       it('should return correct value', async () => {
         const id = new BigNumber(nTokenTypes - 1)
-        const maxSupply = new BigNumber(100)
-        const expected_supply = new BigNumber(3)
-        await SWSupplyManagerContract.functions.setMaxSupplies([id], [maxSupply])
+        const maxIssuance = new BigNumber(100)
+        const expected_issuance = new BigNumber(3)
+        await SWSupplyManagerContract.functions.setMaxIssuances([id], [maxIssuance])
         await SWSupplyManagerContract.functions.activateFactory(factory)
         await SWSupplyManagerContract.functions.addMintPermission(factory, minRange, maxRange)
-        await factoryContract.functions.batchMint(userAddress, [id], [expected_supply], [])
-        const value = await SWSupplyManagerContract.functions.getCurrentSupplies([id])
-        expect(value[0]).to.be.eql(expected_supply)
+        await factoryContract.functions.batchMint(userAddress, [id], [expected_issuance], [])
+        const value = await SWSupplyManagerContract.functions.getCurrentIssuances([id])
+        expect(value[0]).to.be.eql(expected_issuance)
       })
     })
   })
@@ -580,49 +580,49 @@ contract('SWSupplyManager', (accounts: string[]) => {
     })
   })
 
-  describe('setMaxSupplies() function', () => {
+  describe('setMaxIssuances() function', () => {
     const id = new BigNumber(981273918273)
-    const maxSupply = new BigNumber(100)
+    const maxIssuance = new BigNumber(100)
 
     it('should PASS if caller is owner', async () => {
-      const tx = SWSupplyManagerContract.functions.setMaxSupplies([id], [maxSupply])
+      const tx = SWSupplyManagerContract.functions.setMaxIssuances([id], [maxIssuance])
       await expect(tx).to.be.fulfilled
     })
 
     it('should REVERT if caller is not owner', async () => {
-      const tx = userSWSupplyManagerContract.functions.setMaxSupplies([id], [maxSupply])
+      const tx = userSWSupplyManagerContract.functions.setMaxIssuances([id], [maxIssuance])
       await expect(tx).to.be.rejectedWith(RevertError("Ownable#onlyOwner: SENDER_IS_NOT_OWNER"))
     })
 
     it('should REVERT if arrays are not the same length', async () => {
-      const tx = SWSupplyManagerContract.functions.setMaxSupplies([id], [maxSupply, maxSupply])
-      await expect(tx).to.be.rejectedWith(RevertError("SWSupplyManager#setMaxSupply: INVALID_ARRAYS_LENGTH"))
+      const tx = SWSupplyManagerContract.functions.setMaxIssuances([id], [maxIssuance, maxIssuance])
+      await expect(tx).to.be.rejectedWith(RevertError("SWSupplyManager#setMaxIssuances: INVALID_ARRAYS_LENGTH"))
     })
 
-    context('Wen max supply is already set', () => {
+    context('Wen max issuance is already set', () => {
 
       beforeEach(async () => {
-        await SWSupplyManagerContract.functions.setMaxSupplies([id], [maxSupply])
+        await SWSupplyManagerContract.functions.setMaxIssuances([id], [maxIssuance])
       })
 
-      it('should PASS if new max supply is lower', async () => {
-        const tx = SWSupplyManagerContract.functions.setMaxSupplies([id], [maxSupply.sub(1)])
+      it('should PASS if new max issuance is lower', async () => {
+        const tx = SWSupplyManagerContract.functions.setMaxIssuances([id], [maxIssuance.sub(1)])
         await expect(tx).to.be.fulfilled
       })
 
-      it('should REVERT if new max supply is same', async () => {
-        const tx = SWSupplyManagerContract.functions.setMaxSupplies([id], [maxSupply])
-        await expect(tx).to.be.rejectedWith(RevertError("SWSupplyManager#setMaxSupply: INVALID_NEW_MAX_SUPPLY"))
+      it('should REVERT if new max issuance is same', async () => {
+        const tx = SWSupplyManagerContract.functions.setMaxIssuances([id], [maxIssuance])
+        await expect(tx).to.be.rejectedWith(RevertError("SWSupplyManager#setMaxIssuances: INVALID_NEW_MAX_ISSUANCE"))
       })
 
-      it('should REVERT if new max supply is higher', async () => {
-        const tx = SWSupplyManagerContract.functions.setMaxSupplies([id], [maxSupply.add(1)])
-        await expect(tx).to.be.rejectedWith(RevertError("SWSupplyManager#setMaxSupply: INVALID_NEW_MAX_SUPPLY"))
+      it('should REVERT if new max issuance is higher', async () => {
+        const tx = SWSupplyManagerContract.functions.setMaxIssuances([id], [maxIssuance.add(1)])
+        await expect(tx).to.be.rejectedWith(RevertError("SWSupplyManager#setMaxIssuances: INVALID_NEW_MAX_ISSUANCE"))
       })
 
-      it('should REVERT if new max supply is 0', async () => {
-        const tx = SWSupplyManagerContract.functions.setMaxSupplies([id], [0])
-        await expect(tx).to.be.rejectedWith(RevertError("SWSupplyManager#setMaxSupply: INVALID_NEW_MAX_SUPPLY"))
+      it('should REVERT if new max issuance is 0', async () => {
+        const tx = SWSupplyManagerContract.functions.setMaxIssuances([id], [0])
+        await expect(tx).to.be.rejectedWith(RevertError("SWSupplyManager#setMaxIssuances: INVALID_NEW_MAX_ISSUANCE"))
       })
     })
   })
@@ -682,40 +682,40 @@ contract('SWSupplyManager', (accounts: string[]) => {
       await expect(tx).to.be.rejectedWith(RevertError("SWSupplyManager#_validateMints: ID_OUT_OF_RANGE"))
     })
 
-    it('should REVERT if exceeds max supply', async () => {
-      const max_supply = nTokensPerType - 1
+    it('should REVERT if exceeds max issuance', async () => {
+      const max_issuance = nTokensPerType - 1
       const id = nTokenTypes - 1
-      await SWSupplyManagerContract.functions.setMaxSupplies([id], [max_supply])
+      await SWSupplyManagerContract.functions.setMaxIssuances([id], [max_issuance])
       const tx = factoryContract.functions.batchMint(userAddress, ids, amounts, [])
-      await expect(tx).to.be.rejectedWith(RevertError("SWSupplyManager#_validateMints: MAX_SUPPLY_EXCEEDED"))
+      await expect(tx).to.be.rejectedWith(RevertError("SWSupplyManager#_validateMints: MAX_ISSUANCE_EXCEEDED"))
     })
 
-    it('should PASS if reach exact max supply', async () => {
-      const max_supply = nTokensPerType
+    it('should PASS if reach exact max issuance', async () => {
+      const max_issuance = nTokensPerType
       const id = nTokenTypes - 1
-      await SWSupplyManagerContract.functions.setMaxSupplies([id], [max_supply])
+      await SWSupplyManagerContract.functions.setMaxIssuances([id], [max_issuance])
       const tx = factoryContract.functions.batchMint(userAddress, ids, amounts, [])
       await expect(tx).to.be.fulfilled
     })
 
-    it('should update current supply if max supply is set', async () => {
-      const max_supply = nTokensPerType
+    it('should update current issuance if max issuance is set', async () => {
+      const max_issuance = nTokensPerType
       const id = nTokenTypes - 1
-      await SWSupplyManagerContract.functions.setMaxSupplies([id], [max_supply])
+      await SWSupplyManagerContract.functions.setMaxIssuances([id], [max_issuance])
       await factoryContract.functions.batchMint(userAddress, ids, amounts, [])
-      const current_supply = await SWSupplyManagerContract.functions.getCurrentSupplies([id])
-      const get_max_supply = await SWSupplyManagerContract.functions.getMaxSupplies([id])
-      expect(current_supply[0]).to.be.eql(new BigNumber(max_supply))
-      expect(current_supply[0]).to.be.eql(get_max_supply[0])
+      const current_issuance = await SWSupplyManagerContract.functions.getCurrentIssuances([id])
+      const get_max_issuance = await SWSupplyManagerContract.functions.getMaxIssuances([id])
+      expect(current_issuance[0]).to.be.eql(new BigNumber(max_issuance))
+      expect(current_issuance[0]).to.be.eql(get_max_issuance[0])
     })
 
-    it('should NOT update current supply if max supply is NOT set', async () => {
+    it('should NOT update current issuance if max issuance is NOT set', async () => {
       const id = nTokenTypes - 1
       await factoryContract.functions.batchMint(userAddress, ids, amounts, [])
-      const current_supply = await SWSupplyManagerContract.functions.getCurrentSupplies([id])
-      const get_max_supply = await SWSupplyManagerContract.functions.getMaxSupplies([id])
-      expect(current_supply[0]).to.be.eql(new BigNumber(0))
-      expect(current_supply[0]).to.be.eql(get_max_supply[0])
+      const current_issuance = await SWSupplyManagerContract.functions.getCurrentIssuances([id])
+      const get_max_issuance = await SWSupplyManagerContract.functions.getMaxIssuances([id])
+      expect(current_issuance[0]).to.be.eql(new BigNumber(0))
+      expect(current_issuance[0]).to.be.eql(get_max_issuance[0])
     })
 
     it('should PASS if caller is activated and authorized factory', async () => {
@@ -833,40 +833,40 @@ contract('SWSupplyManager', (accounts: string[]) => {
       await expect(tx3).to.be.rejectedWith(RevertError("SWSupplyManager#_validateMints: ID_OUT_OF_RANGE"))
     })
 
-    it('should REVERT if exceeds max supply', async () => {
-      const max_supply = nTokensPerType - 1
+    it('should REVERT if exceeds max issuance', async () => {
+      const max_issuance = nTokensPerType - 1
       const id = nTokenTypes - 1
-      await SWSupplyManagerContract.functions.setMaxSupplies([id], [max_supply])
+      await SWSupplyManagerContract.functions.setMaxIssuances([id], [max_issuance])
       const tx = factoryContract.functions.mint(userAddress, id, amount, [])
-      await expect(tx).to.be.rejectedWith(RevertError("SWSupplyManager#_validateMints: MAX_SUPPLY_EXCEEDED"))
+      await expect(tx).to.be.rejectedWith(RevertError("SWSupplyManager#_validateMints: MAX_ISSUANCE_EXCEEDED"))
     })
 
-    it('should PASS if reach exact max supply', async () => {
-      const max_supply = nTokensPerType
+    it('should PASS if reach exact max issuance', async () => {
+      const max_issuance = nTokensPerType
       const id = nTokenTypes - 1
-      await SWSupplyManagerContract.functions.setMaxSupplies([id], [max_supply])
+      await SWSupplyManagerContract.functions.setMaxIssuances([id], [max_issuance])
       const tx = factoryContract.functions.mint(userAddress, id, amount, [])
       await expect(tx).to.be.fulfilled
     })
 
-    it('should update current supply if max supply is set', async () => {
-      const max_supply = nTokensPerType
+    it('should update current issuance if max issuance is set', async () => {
+      const max_issuance = nTokensPerType
       const id = nTokenTypes - 1
-      await SWSupplyManagerContract.functions.setMaxSupplies([id], [max_supply])
+      await SWSupplyManagerContract.functions.setMaxIssuances([id], [max_issuance])
       await factoryContract.functions.mint(userAddress, id, amount, [])
-      const current_supply = await SWSupplyManagerContract.functions.getCurrentSupplies([id])
-      const get_max_supply = await SWSupplyManagerContract.functions.getMaxSupplies([id])
-      expect(current_supply[0]).to.be.eql(new BigNumber(max_supply))
-      expect(current_supply[0]).to.be.eql(get_max_supply[0])
+      const current_issuance = await SWSupplyManagerContract.functions.getCurrentIssuances([id])
+      const get_max_issuance = await SWSupplyManagerContract.functions.getMaxIssuances([id])
+      expect(current_issuance[0]).to.be.eql(new BigNumber(max_issuance))
+      expect(current_issuance[0]).to.be.eql(get_max_issuance[0])
     })
 
-    it('should NOT update current supply if max supply is NOT set', async () => {
+    it('should NOT update current issuance if max issuance is NOT set', async () => {
       const id = nTokenTypes - 1
       await factoryContract.functions.mint(userAddress, id, amount, [])
-      const current_supply = await SWSupplyManagerContract.functions.getCurrentSupplies([id])
-      const get_max_supply = await SWSupplyManagerContract.functions.getMaxSupplies([id])
-      expect(current_supply[0]).to.be.eql(new BigNumber(0))
-      expect(current_supply[0]).to.be.eql(get_max_supply[0])
+      const current_issuance = await SWSupplyManagerContract.functions.getCurrentIssuances([id])
+      const get_max_issuance = await SWSupplyManagerContract.functions.getMaxIssuances([id])
+      expect(current_issuance[0]).to.be.eql(new BigNumber(0))
+      expect(current_issuance[0]).to.be.eql(get_max_issuance[0])
     })
 
     it('should PASS if caller is activated and authorized factory', async () => {

--- a/typings/contracts/ISWSupplyManager.d.ts
+++ b/typings/contracts/ISWSupplyManager.d.ts
@@ -12,8 +12,11 @@ import {
 
 interface ISWSupplyManagerInterface extends Interface {
   functions: {
-    setMaxSupplies: TypedFunctionDescription<{
-      encode([_ids, _supplies]: [BigNumberish[], BigNumberish[]]): string;
+    setMaxIssuances: TypedFunctionDescription<{
+      encode([_ids, _newMaxIssuances]: [
+        BigNumberish[],
+        BigNumberish[]
+      ]): string;
     }>;
 
     addMintPermission: TypedFunctionDescription<{
@@ -66,11 +69,11 @@ interface ISWSupplyManagerInterface extends Interface {
       encode([_factory]: [string]): string;
     }>;
 
-    getMaxSupplies: TypedFunctionDescription<{
+    getMaxIssuances: TypedFunctionDescription<{
       encode([_ids]: [BigNumberish[]]): string;
     }>;
 
-    getCurrentSupplies: TypedFunctionDescription<{
+    getCurrentIssuances: TypedFunctionDescription<{
       encode([_ids]: [BigNumberish[]]): string;
     }>;
   };
@@ -111,9 +114,9 @@ export class ISWSupplyManager extends Contract {
   interface: ISWSupplyManagerInterface;
 
   functions: {
-    setMaxSupplies(
+    setMaxIssuances(
       _ids: BigNumberish[],
-      _supplies: BigNumberish[],
+      _newMaxIssuances: BigNumberish[],
       overrides?: TransactionOverrides
     ): Promise<ContractTransaction>;
 
@@ -167,14 +170,14 @@ export class ISWSupplyManager extends Contract {
       _factory: string
     ): Promise<{ minID: BigNumber; maxID: BigNumber }[]>;
 
-    getMaxSupplies(_ids: BigNumberish[]): Promise<BigNumber[]>;
+    getMaxIssuances(_ids: BigNumberish[]): Promise<BigNumber[]>;
 
-    getCurrentSupplies(_ids: BigNumberish[]): Promise<BigNumber[]>;
+    getCurrentIssuances(_ids: BigNumberish[]): Promise<BigNumber[]>;
   };
 
-  setMaxSupplies(
+  setMaxIssuances(
     _ids: BigNumberish[],
-    _supplies: BigNumberish[],
+    _newMaxIssuances: BigNumberish[],
     overrides?: TransactionOverrides
   ): Promise<ContractTransaction>;
 
@@ -228,9 +231,9 @@ export class ISWSupplyManager extends Contract {
     _factory: string
   ): Promise<{ minID: BigNumber; maxID: BigNumber }[]>;
 
-  getMaxSupplies(_ids: BigNumberish[]): Promise<BigNumber[]>;
+  getMaxIssuances(_ids: BigNumberish[]): Promise<BigNumber[]>;
 
-  getCurrentSupplies(_ids: BigNumberish[]): Promise<BigNumber[]>;
+  getCurrentIssuances(_ids: BigNumberish[]): Promise<BigNumber[]>;
 
   filters: {
     FactoryActivation(factory: string | null): EventFilter;
@@ -246,9 +249,9 @@ export class ISWSupplyManager extends Contract {
   };
 
   estimate: {
-    setMaxSupplies(
+    setMaxIssuances(
       _ids: BigNumberish[],
-      _supplies: BigNumberish[]
+      _newMaxIssuances: BigNumberish[]
     ): Promise<BigNumber>;
 
     addMintPermission(
@@ -289,8 +292,8 @@ export class ISWSupplyManager extends Contract {
 
     getFactoryAccessRanges(_factory: string): Promise<BigNumber>;
 
-    getMaxSupplies(_ids: BigNumberish[]): Promise<BigNumber>;
+    getMaxIssuances(_ids: BigNumberish[]): Promise<BigNumber>;
 
-    getCurrentSupplies(_ids: BigNumberish[]): Promise<BigNumber>;
+    getCurrentIssuances(_ids: BigNumberish[]): Promise<BigNumber>;
   };
 }

--- a/typings/contracts/ISkyweaverAssets.d.ts
+++ b/typings/contracts/ISkyweaverAssets.d.ts
@@ -24,7 +24,7 @@ interface ISkyweaverAssetsInterface extends Interface {
       ]): string;
     }>;
 
-    getCurrentSupplies: TypedFunctionDescription<{
+    getCurrentIssuances: TypedFunctionDescription<{
       encode([_ids]: [BigNumberish[]]): string;
     }>;
 
@@ -36,7 +36,7 @@ interface ISkyweaverAssetsInterface extends Interface {
       encode([_factory]: [string]): string;
     }>;
 
-    getMaxSupplies: TypedFunctionDescription<{
+    getMaxIssuances: TypedFunctionDescription<{
       encode([_ids]: [BigNumberish[]]): string;
     }>;
 
@@ -48,8 +48,11 @@ interface ISkyweaverAssetsInterface extends Interface {
       encode([_factory, _rangeIndex]: [string, BigNumberish]): string;
     }>;
 
-    setMaxSupplies: TypedFunctionDescription<{
-      encode([_ids, _supplies]: [BigNumberish[], BigNumberish[]]): string;
+    setMaxIssuances: TypedFunctionDescription<{
+      encode([_ids, _newMaxIssuances]: [
+        BigNumberish[],
+        BigNumberish[]
+      ]): string;
     }>;
 
     shutdownFactory: TypedFunctionDescription<{
@@ -161,7 +164,7 @@ export class ISkyweaverAssets extends Contract {
       overrides?: TransactionOverrides
     ): Promise<ContractTransaction>;
 
-    getCurrentSupplies(_ids: BigNumberish[]): Promise<BigNumber[]>;
+    getCurrentIssuances(_ids: BigNumberish[]): Promise<BigNumber[]>;
 
     getFactoryAccessRanges(
       _factory: string
@@ -169,7 +172,7 @@ export class ISkyweaverAssets extends Contract {
 
     getFactoryStatus(_factory: string): Promise<boolean>;
 
-    getMaxSupplies(_ids: BigNumberish[]): Promise<BigNumber[]>;
+    getMaxIssuances(_ids: BigNumberish[]): Promise<BigNumber[]>;
 
     lockRangeMintPermissions(
       _range: { minID: BigNumberish; maxID: BigNumberish },
@@ -182,9 +185,9 @@ export class ISkyweaverAssets extends Contract {
       overrides?: TransactionOverrides
     ): Promise<ContractTransaction>;
 
-    setMaxSupplies(
+    setMaxIssuances(
       _ids: BigNumberish[],
-      _supplies: BigNumberish[],
+      _newMaxIssuances: BigNumberish[],
       overrides?: TransactionOverrides
     ): Promise<ContractTransaction>;
 
@@ -264,7 +267,7 @@ export class ISkyweaverAssets extends Contract {
     overrides?: TransactionOverrides
   ): Promise<ContractTransaction>;
 
-  getCurrentSupplies(_ids: BigNumberish[]): Promise<BigNumber[]>;
+  getCurrentIssuances(_ids: BigNumberish[]): Promise<BigNumber[]>;
 
   getFactoryAccessRanges(
     _factory: string
@@ -272,7 +275,7 @@ export class ISkyweaverAssets extends Contract {
 
   getFactoryStatus(_factory: string): Promise<boolean>;
 
-  getMaxSupplies(_ids: BigNumberish[]): Promise<BigNumber[]>;
+  getMaxIssuances(_ids: BigNumberish[]): Promise<BigNumber[]>;
 
   lockRangeMintPermissions(
     _range: { minID: BigNumberish; maxID: BigNumberish },
@@ -285,9 +288,9 @@ export class ISkyweaverAssets extends Contract {
     overrides?: TransactionOverrides
   ): Promise<ContractTransaction>;
 
-  setMaxSupplies(
+  setMaxIssuances(
     _ids: BigNumberish[],
-    _supplies: BigNumberish[],
+    _newMaxIssuances: BigNumberish[],
     overrides?: TransactionOverrides
   ): Promise<ContractTransaction>;
 
@@ -376,13 +379,13 @@ export class ISkyweaverAssets extends Contract {
       _maxRange: BigNumberish
     ): Promise<BigNumber>;
 
-    getCurrentSupplies(_ids: BigNumberish[]): Promise<BigNumber>;
+    getCurrentIssuances(_ids: BigNumberish[]): Promise<BigNumber>;
 
     getFactoryAccessRanges(_factory: string): Promise<BigNumber>;
 
     getFactoryStatus(_factory: string): Promise<BigNumber>;
 
-    getMaxSupplies(_ids: BigNumberish[]): Promise<BigNumber>;
+    getMaxIssuances(_ids: BigNumberish[]): Promise<BigNumber>;
 
     lockRangeMintPermissions(_range: {
       minID: BigNumberish;
@@ -394,9 +397,9 @@ export class ISkyweaverAssets extends Contract {
       _rangeIndex: BigNumberish
     ): Promise<BigNumber>;
 
-    setMaxSupplies(
+    setMaxIssuances(
       _ids: BigNumberish[],
-      _supplies: BigNumberish[]
+      _newMaxIssuances: BigNumberish[]
     ): Promise<BigNumber>;
 
     shutdownFactory(_factory: string): Promise<BigNumber>;

--- a/typings/contracts/SWSupplyManager.d.ts
+++ b/typings/contracts/SWSupplyManager.d.ts
@@ -80,8 +80,11 @@ interface SWSupplyManagerInterface extends Interface {
       encode([_range]: [{ minID: BigNumberish; maxID: BigNumberish }]): string;
     }>;
 
-    setMaxSupplies: TypedFunctionDescription<{
-      encode([_ids, _newMaxSupplies]: [BigNumberish[], BigNumberish[]]): string;
+    setMaxIssuances: TypedFunctionDescription<{
+      encode([_ids, _newMaxIssuances]: [
+        BigNumberish[],
+        BigNumberish[]
+      ]): string;
     }>;
 
     batchMint: TypedFunctionDescription<{
@@ -102,11 +105,11 @@ interface SWSupplyManagerInterface extends Interface {
       ]): string;
     }>;
 
-    getMaxSupplies: TypedFunctionDescription<{
+    getMaxIssuances: TypedFunctionDescription<{
       encode([_ids]: [BigNumberish[]]): string;
     }>;
 
-    getCurrentSupplies: TypedFunctionDescription<{
+    getCurrentIssuances: TypedFunctionDescription<{
       encode([_ids]: [BigNumberish[]]): string;
     }>;
 
@@ -154,8 +157,8 @@ interface SWSupplyManagerInterface extends Interface {
       encodeTopics([factory]: [string | null]): string[];
     }>;
 
-    MaxSuppliesChanged: TypedEventDescription<{
-      encodeTopics([ids, newMaxSupplies]: [null, null]): string[];
+    MaxIssuancesChanged: TypedEventDescription<{
+      encodeTopics([ids, newMaxIssuances]: [null, null]): string[];
     }>;
 
     MintPermissionAdded: TypedEventDescription<{
@@ -290,9 +293,9 @@ export class SWSupplyManager extends Contract {
       overrides?: TransactionOverrides
     ): Promise<ContractTransaction>;
 
-    setMaxSupplies(
+    setMaxIssuances(
       _ids: BigNumberish[],
-      _newMaxSupplies: BigNumberish[],
+      _newMaxIssuances: BigNumberish[],
       overrides?: TransactionOverrides
     ): Promise<ContractTransaction>;
 
@@ -312,9 +315,9 @@ export class SWSupplyManager extends Contract {
       overrides?: TransactionOverrides
     ): Promise<ContractTransaction>;
 
-    getMaxSupplies(_ids: BigNumberish[]): Promise<BigNumber[]>;
+    getMaxIssuances(_ids: BigNumberish[]): Promise<BigNumber[]>;
 
-    getCurrentSupplies(_ids: BigNumberish[]): Promise<BigNumber[]>;
+    getCurrentIssuances(_ids: BigNumberish[]): Promise<BigNumber[]>;
 
     getFactoryStatus(_factory: string): Promise<boolean>;
 
@@ -414,9 +417,9 @@ export class SWSupplyManager extends Contract {
     overrides?: TransactionOverrides
   ): Promise<ContractTransaction>;
 
-  setMaxSupplies(
+  setMaxIssuances(
     _ids: BigNumberish[],
-    _newMaxSupplies: BigNumberish[],
+    _newMaxIssuances: BigNumberish[],
     overrides?: TransactionOverrides
   ): Promise<ContractTransaction>;
 
@@ -436,9 +439,9 @@ export class SWSupplyManager extends Contract {
     overrides?: TransactionOverrides
   ): Promise<ContractTransaction>;
 
-  getMaxSupplies(_ids: BigNumberish[]): Promise<BigNumber[]>;
+  getMaxIssuances(_ids: BigNumberish[]): Promise<BigNumber[]>;
 
-  getCurrentSupplies(_ids: BigNumberish[]): Promise<BigNumber[]>;
+  getCurrentIssuances(_ids: BigNumberish[]): Promise<BigNumber[]>;
 
   getFactoryStatus(_factory: string): Promise<boolean>;
 
@@ -481,7 +484,7 @@ export class SWSupplyManager extends Contract {
 
     FactoryShutdown(factory: string | null): EventFilter;
 
-    MaxSuppliesChanged(ids: null, newMaxSupplies: null): EventFilter;
+    MaxIssuancesChanged(ids: null, newMaxIssuances: null): EventFilter;
 
     MintPermissionAdded(factory: string | null, new_range: null): EventFilter;
 
@@ -570,9 +573,9 @@ export class SWSupplyManager extends Contract {
       maxID: BigNumberish;
     }): Promise<BigNumber>;
 
-    setMaxSupplies(
+    setMaxIssuances(
       _ids: BigNumberish[],
-      _newMaxSupplies: BigNumberish[]
+      _newMaxIssuances: BigNumberish[]
     ): Promise<BigNumber>;
 
     batchMint(
@@ -589,9 +592,9 @@ export class SWSupplyManager extends Contract {
       _data: Arrayish
     ): Promise<BigNumber>;
 
-    getMaxSupplies(_ids: BigNumberish[]): Promise<BigNumber>;
+    getMaxIssuances(_ids: BigNumberish[]): Promise<BigNumber>;
 
-    getCurrentSupplies(_ids: BigNumberish[]): Promise<BigNumber>;
+    getCurrentIssuances(_ids: BigNumberish[]): Promise<BigNumber>;
 
     getFactoryStatus(_factory: string): Promise<BigNumber>;
 

--- a/typings/contracts/SkyweaverAssets.d.ts
+++ b/typings/contracts/SkyweaverAssets.d.ts
@@ -49,7 +49,7 @@ interface SkyweaverAssetsInterface extends Interface {
       encode([_id, _amount]: [BigNumberish, BigNumberish]): string;
     }>;
 
-    getCurrentSupplies: TypedFunctionDescription<{
+    getCurrentIssuances: TypedFunctionDescription<{
       encode([_ids]: [BigNumberish[]]): string;
     }>;
 
@@ -67,7 +67,7 @@ interface SkyweaverAssetsInterface extends Interface {
 
     getLockedRanges: TypedFunctionDescription<{ encode([]: []): string }>;
 
-    getMaxSupplies: TypedFunctionDescription<{
+    getMaxIssuances: TypedFunctionDescription<{
       encode([_ids]: [BigNumberish[]]): string;
     }>;
 
@@ -173,8 +173,11 @@ interface SkyweaverAssetsInterface extends Interface {
       encode([_newBaseMetadataURI]: [string]): string;
     }>;
 
-    setMaxSupplies: TypedFunctionDescription<{
-      encode([_ids, _newMaxSupplies]: [BigNumberish[], BigNumberish[]]): string;
+    setMaxIssuances: TypedFunctionDescription<{
+      encode([_ids, _newMaxIssuances]: [
+        BigNumberish[],
+        BigNumberish[]
+      ]): string;
     }>;
 
     shutdownFactory: TypedFunctionDescription<{
@@ -209,8 +212,8 @@ interface SkyweaverAssetsInterface extends Interface {
       encodeTopics([factory]: [string | null]): string[];
     }>;
 
-    MaxSuppliesChanged: TypedEventDescription<{
-      encodeTopics([ids, newMaxSupplies]: [null, null]): string[];
+    MaxIssuancesChanged: TypedEventDescription<{
+      encodeTopics([ids, newMaxIssuances]: [null, null]): string[];
     }>;
 
     MintPermissionAdded: TypedEventDescription<{
@@ -318,7 +321,7 @@ export class SkyweaverAssets extends Contract {
       overrides?: TransactionOverrides
     ): Promise<ContractTransaction>;
 
-    getCurrentSupplies(_ids: BigNumberish[]): Promise<BigNumber[]>;
+    getCurrentIssuances(_ids: BigNumberish[]): Promise<BigNumber[]>;
 
     getFactoryAccessRanges(
       _factory: string
@@ -337,7 +340,7 @@ export class SkyweaverAssets extends Contract {
 
     getLockedRanges(): Promise<{ minID: BigNumber; maxID: BigNumber }[]>;
 
-    getMaxSupplies(_ids: BigNumberish[]): Promise<BigNumber[]>;
+    getMaxIssuances(_ids: BigNumberish[]): Promise<BigNumber[]>;
 
     getNonce(_signer: string): Promise<BigNumber>;
 
@@ -439,9 +442,9 @@ export class SkyweaverAssets extends Contract {
       overrides?: TransactionOverrides
     ): Promise<ContractTransaction>;
 
-    setMaxSupplies(
+    setMaxIssuances(
       _ids: BigNumberish[],
-      _newMaxSupplies: BigNumberish[],
+      _newMaxIssuances: BigNumberish[],
       overrides?: TransactionOverrides
     ): Promise<ContractTransaction>;
 
@@ -496,7 +499,7 @@ export class SkyweaverAssets extends Contract {
     overrides?: TransactionOverrides
   ): Promise<ContractTransaction>;
 
-  getCurrentSupplies(_ids: BigNumberish[]): Promise<BigNumber[]>;
+  getCurrentIssuances(_ids: BigNumberish[]): Promise<BigNumber[]>;
 
   getFactoryAccessRanges(
     _factory: string
@@ -515,7 +518,7 @@ export class SkyweaverAssets extends Contract {
 
   getLockedRanges(): Promise<{ minID: BigNumber; maxID: BigNumber }[]>;
 
-  getMaxSupplies(_ids: BigNumberish[]): Promise<BigNumber[]>;
+  getMaxIssuances(_ids: BigNumberish[]): Promise<BigNumber[]>;
 
   getNonce(_signer: string): Promise<BigNumber>;
 
@@ -617,9 +620,9 @@ export class SkyweaverAssets extends Contract {
     overrides?: TransactionOverrides
   ): Promise<ContractTransaction>;
 
-  setMaxSupplies(
+  setMaxIssuances(
     _ids: BigNumberish[],
-    _newMaxSupplies: BigNumberish[],
+    _newMaxIssuances: BigNumberish[],
     overrides?: TransactionOverrides
   ): Promise<ContractTransaction>;
 
@@ -648,7 +651,7 @@ export class SkyweaverAssets extends Contract {
 
     FactoryShutdown(factory: string | null): EventFilter;
 
-    MaxSuppliesChanged(ids: null, newMaxSupplies: null): EventFilter;
+    MaxIssuancesChanged(ids: null, newMaxIssuances: null): EventFilter;
 
     MintPermissionAdded(factory: string | null, new_range: null): EventFilter;
 
@@ -712,7 +715,7 @@ export class SkyweaverAssets extends Contract {
 
     burn(_id: BigNumberish, _amount: BigNumberish): Promise<BigNumber>;
 
-    getCurrentSupplies(_ids: BigNumberish[]): Promise<BigNumber>;
+    getCurrentIssuances(_ids: BigNumberish[]): Promise<BigNumber>;
 
     getFactoryAccessRanges(_factory: string): Promise<BigNumber>;
 
@@ -722,7 +725,7 @@ export class SkyweaverAssets extends Contract {
 
     getLockedRanges(): Promise<BigNumber>;
 
-    getMaxSupplies(_ids: BigNumberish[]): Promise<BigNumber>;
+    getMaxIssuances(_ids: BigNumberish[]): Promise<BigNumber>;
 
     getNonce(_signer: string): Promise<BigNumber>;
 
@@ -810,9 +813,9 @@ export class SkyweaverAssets extends Contract {
 
     setBaseMetadataURI(_newBaseMetadataURI: string): Promise<BigNumber>;
 
-    setMaxSupplies(
+    setMaxIssuances(
       _ids: BigNumberish[],
-      _newMaxSupplies: BigNumberish[]
+      _newMaxIssuances: BigNumberish[]
     ): Promise<BigNumber>;
 
     shutdownFactory(_factory: string): Promise<BigNumber>;

--- a/typings/contracts/SkyweaverCurrencies.d.ts
+++ b/typings/contracts/SkyweaverCurrencies.d.ts
@@ -49,7 +49,7 @@ interface SkyweaverCurrenciesInterface extends Interface {
       encode([_id, _amount]: [BigNumberish, BigNumberish]): string;
     }>;
 
-    getCurrentSupplies: TypedFunctionDescription<{
+    getCurrentIssuances: TypedFunctionDescription<{
       encode([_ids]: [BigNumberish[]]): string;
     }>;
 
@@ -63,7 +63,7 @@ interface SkyweaverCurrenciesInterface extends Interface {
 
     getLockedRanges: TypedFunctionDescription<{ encode([]: []): string }>;
 
-    getMaxSupplies: TypedFunctionDescription<{
+    getMaxIssuances: TypedFunctionDescription<{
       encode([_ids]: [BigNumberish[]]): string;
     }>;
 
@@ -165,8 +165,11 @@ interface SkyweaverCurrenciesInterface extends Interface {
       encode([_newBaseMetadataURI]: [string]): string;
     }>;
 
-    setMaxSupplies: TypedFunctionDescription<{
-      encode([_ids, _newMaxSupplies]: [BigNumberish[], BigNumberish[]]): string;
+    setMaxIssuances: TypedFunctionDescription<{
+      encode([_ids, _newMaxIssuances]: [
+        BigNumberish[],
+        BigNumberish[]
+      ]): string;
     }>;
 
     shutdownFactory: TypedFunctionDescription<{
@@ -201,8 +204,8 @@ interface SkyweaverCurrenciesInterface extends Interface {
       encodeTopics([factory]: [string | null]): string[];
     }>;
 
-    MaxSuppliesChanged: TypedEventDescription<{
-      encodeTopics([ids, newMaxSupplies]: [null, null]): string[];
+    MaxIssuancesChanged: TypedEventDescription<{
+      encodeTopics([ids, newMaxIssuances]: [null, null]): string[];
     }>;
 
     MintPermissionAdded: TypedEventDescription<{
@@ -310,7 +313,7 @@ export class SkyweaverCurrencies extends Contract {
       overrides?: TransactionOverrides
     ): Promise<ContractTransaction>;
 
-    getCurrentSupplies(_ids: BigNumberish[]): Promise<BigNumber[]>;
+    getCurrentIssuances(_ids: BigNumberish[]): Promise<BigNumber[]>;
 
     getFactoryAccessRanges(
       _factory: string
@@ -320,7 +323,7 @@ export class SkyweaverCurrencies extends Contract {
 
     getLockedRanges(): Promise<{ minID: BigNumber; maxID: BigNumber }[]>;
 
-    getMaxSupplies(_ids: BigNumberish[]): Promise<BigNumber[]>;
+    getMaxIssuances(_ids: BigNumberish[]): Promise<BigNumber[]>;
 
     getNonce(_signer: string): Promise<BigNumber>;
 
@@ -417,9 +420,9 @@ export class SkyweaverCurrencies extends Contract {
       overrides?: TransactionOverrides
     ): Promise<ContractTransaction>;
 
-    setMaxSupplies(
+    setMaxIssuances(
       _ids: BigNumberish[],
-      _newMaxSupplies: BigNumberish[],
+      _newMaxIssuances: BigNumberish[],
       overrides?: TransactionOverrides
     ): Promise<ContractTransaction>;
 
@@ -474,7 +477,7 @@ export class SkyweaverCurrencies extends Contract {
     overrides?: TransactionOverrides
   ): Promise<ContractTransaction>;
 
-  getCurrentSupplies(_ids: BigNumberish[]): Promise<BigNumber[]>;
+  getCurrentIssuances(_ids: BigNumberish[]): Promise<BigNumber[]>;
 
   getFactoryAccessRanges(
     _factory: string
@@ -484,7 +487,7 @@ export class SkyweaverCurrencies extends Contract {
 
   getLockedRanges(): Promise<{ minID: BigNumber; maxID: BigNumber }[]>;
 
-  getMaxSupplies(_ids: BigNumberish[]): Promise<BigNumber[]>;
+  getMaxIssuances(_ids: BigNumberish[]): Promise<BigNumber[]>;
 
   getNonce(_signer: string): Promise<BigNumber>;
 
@@ -581,9 +584,9 @@ export class SkyweaverCurrencies extends Contract {
     overrides?: TransactionOverrides
   ): Promise<ContractTransaction>;
 
-  setMaxSupplies(
+  setMaxIssuances(
     _ids: BigNumberish[],
-    _newMaxSupplies: BigNumberish[],
+    _newMaxIssuances: BigNumberish[],
     overrides?: TransactionOverrides
   ): Promise<ContractTransaction>;
 
@@ -612,7 +615,7 @@ export class SkyweaverCurrencies extends Contract {
 
     FactoryShutdown(factory: string | null): EventFilter;
 
-    MaxSuppliesChanged(ids: null, newMaxSupplies: null): EventFilter;
+    MaxIssuancesChanged(ids: null, newMaxIssuances: null): EventFilter;
 
     MintPermissionAdded(factory: string | null, new_range: null): EventFilter;
 
@@ -676,7 +679,7 @@ export class SkyweaverCurrencies extends Contract {
 
     burn(_id: BigNumberish, _amount: BigNumberish): Promise<BigNumber>;
 
-    getCurrentSupplies(_ids: BigNumberish[]): Promise<BigNumber>;
+    getCurrentIssuances(_ids: BigNumberish[]): Promise<BigNumber>;
 
     getFactoryAccessRanges(_factory: string): Promise<BigNumber>;
 
@@ -684,7 +687,7 @@ export class SkyweaverCurrencies extends Contract {
 
     getLockedRanges(): Promise<BigNumber>;
 
-    getMaxSupplies(_ids: BigNumberish[]): Promise<BigNumber>;
+    getMaxIssuances(_ids: BigNumberish[]): Promise<BigNumber>;
 
     getNonce(_signer: string): Promise<BigNumber>;
 
@@ -767,9 +770,9 @@ export class SkyweaverCurrencies extends Contract {
 
     setBaseMetadataURI(_newBaseMetadataURI: string): Promise<BigNumber>;
 
-    setMaxSupplies(
+    setMaxIssuances(
       _ids: BigNumberish[],
-      _newMaxSupplies: BigNumberish[]
+      _newMaxIssuances: BigNumberish[]
     ): Promise<BigNumber>;
 
     shutdownFactory(_factory: string): Promise<BigNumber>;


### PR DESCRIPTION
Addresses https://diligence.consensys.net/audits/private/tgdwwgo4-skyweaver/?#supply-limitation-misbehaviors by renaming the term "currentSupply" to "currentIssuance" and "maxSupply" to "maxIssuance". 

These variables do not track the actual supply of cards, hence the terms were misleading. All tests pass but need to double check that no functionality was changed by accident @Agusx1211 :pray: 