### PR TITLE
Use random initial salt nonce

### DIFF
--- a/contracts/factories/BridgeFactory.sol
+++ b/contracts/factories/BridgeFactory.sol
@@ -34,7 +34,7 @@ contract BridgeFactory is IERC1155TokenReceiver, TieredOwnable {
   uint256 constant internal PERIOD_LENGTH = 6 hours; // Length of each mint periods
 
   // Nonce to be used when salt is not provided by the users for Deposit and Redeposit events
-  uint256 internal saltNonce; 
+  uint256 internal saltNonce = uint256(keccak256("org.skyweaver.bridge.initial.nonce")); 
 
   event PeriodMintLimitChanged(uint256 oldMintingLimit, uint256 newMintingLimit);
   event Deposit(address indexed recipient, bytes32 salt);


### PR DESCRIPTION
Starting the `saltNonce` on `0` could result in collisions with wallets that implement the `salt` using an auto-incremental uint.
Using a random value doesn't have any additional cost, and may prevent those simple collisions.